### PR TITLE
Fixed compiler error for deprecated function

### DIFF
--- a/src/littlewing/game.rs
+++ b/src/littlewing/game.rs
@@ -57,7 +57,7 @@ impl Game {
             (0..8)
                 .map(|j| {
                     let c = (self.board[8 * (7 - i) + j as usize]).to_char();
-                    String::from_str("| ") + c.to_string().as_str() + " "
+                    String::from("| ") + c.to_string().as_str() + " "
                 })
                 .fold(String::new(), |r, s| {
                     r + s.as_str()

--- a/src/littlewing/protocols/xboard.rs
+++ b/src/littlewing/protocols/xboard.rs
@@ -128,8 +128,8 @@ impl XBoard {
         }
 
         let side = self.game.positions.top().side;
-        let from: Square = SquareString::from_coord(String::from_str(&args[0][0..2]));
-        let to: Square = SquareString::from_coord(String::from_str(&args[0][2..4]));
+        let from: Square = SquareString::from_coord(String::from(&args[0][0..2]));
+        let to: Square = SquareString::from_coord(String::from(&args[0][2..4]));
 
         let piece = self.game.board[from as usize];
         let capture = self.game.board[to as usize];


### PR DESCRIPTION
String::from_str has been deprecated in favor of String::from
“Deprecated since 1.2.0: use String::from instead”