### PR TITLE
Fix xboard level 0 command crash

### DIFF
--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -113,7 +113,14 @@ impl XBoard {
     }
 
     pub fn cmd_level(&mut self, args: &[&str]) {
-        let moves = args[1].parse::<u16>().unwrap();
+        let mut moves = args[1].parse::<u16>().unwrap();
+
+        if moves == 0 {
+            // FIXME: 0 means "play the whole game in this time control period"
+            // which is unsupported by our time management so we set it to
+            // another value instead.
+            moves = 60;
+        }
 
         // `time` is given in `mm:ss` or `ss`.
         let time = match args[2].find(':') {


### PR DESCRIPTION
This is a temporary fix to avoid crashing the engine when xboard `level 0 5 0` command is encountered.

See https://github.com/vinc/littlewing/issues/3