### PR TITLE
Parse moves in SAN format

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ and in addition it has its own text-based user interface:
       +---+---+---+---+---+---+---+---+
         a   b   c   d   e   f   g   h
 
-    > move e2e4
+    > move e4
 
       +---+---+---+---+---+---+---+---+
       | r | n | b | q | k | b | n | r | 8
@@ -155,7 +155,7 @@ and in addition it has its own text-based user interface:
        12    -23     363    2254362  1. ... e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Nf6 5. Nc3 d5 6. exd5 Nxd5 7. Bc4
        13    -13     690    4457080  1. ... e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Nf6 5. Nc3 d5 6. exd5 Nxd5 7. Bc4
 
-    < move e7e5
+    < move e5
 
       +---+---+---+---+---+---+---+---+
       | r | n | b | q | k | b | n | r | 8

--- a/benches/littlewing.rs
+++ b/benches/littlewing.rs
@@ -45,7 +45,7 @@ fn bench_next_move_without_ordering(b: &mut Bencher) {
 #[bench]
 fn bench_make_undo_move(b: &mut Bencher) {
     let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-    let m = game.move_from_can("e2e4");
+    let m = game.move_from_lan("e2e4");
 
     b.iter(|| {
         game.make_move(m);
@@ -74,7 +74,7 @@ fn bench_eval_material(b: &mut Bencher) {
 #[bench]
 fn bench_see(b: &mut Bencher) {
     let mut game = Game::from_fen("rnbqkb1r/pp2pppp/2p2n2/1B1p4/4P3/2N5/PPPP1PPP/R1BQK1NR w KQkq - 0 4");
-    let m = game.move_from_can("c2d5");
+    let m = game.move_from_lan("c2d5");
 
     b.iter(|| {
         game.see(m)
@@ -99,10 +99,10 @@ fn bench_perft(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_move_from_can(b: &mut Bencher) {
+fn bench_move_from_lan(b: &mut Bencher) {
     let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     b.iter(|| {
-        game.move_from_can("e2e4");
+        game.move_from_lan("e2e4");
     });
 }
 

--- a/benches/littlewing.rs
+++ b/benches/littlewing.rs
@@ -97,3 +97,19 @@ fn bench_perft(b: &mut Bencher) {
         game.perft(3)
     });
 }
+
+#[bench]
+fn bench_move_from_can(b: &mut Bencher) {
+    let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    b.iter(|| {
+        game.move_from_can("e2e4");
+    });
+}
+
+#[bench]
+fn bench_move_from_san(b: &mut Bencher) {
+    let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    b.iter(|| {
+        game.move_from_san("e4");
+    });
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -79,6 +79,17 @@ pub const RANK_6: Bitboard = 0x0000FF0000000000;
 pub const RANK_7: Bitboard = 0x00FF000000000000;
 pub const RANK_8: Bitboard = 0xFF00000000000000;
 
+pub const RANKS: [Bitboard; 8] = [
+    RANK_1,
+    RANK_2,
+    RANK_3,
+    RANK_4,
+    RANK_5,
+    RANK_6,
+    RANK_7,
+    RANK_8,
+];
+
 pub const FILE_A: Bitboard = 0x0101010101010101;
 pub const FILE_B: Bitboard = 0x0202020202020202;
 pub const FILE_C: Bitboard = 0x0404040404040404;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!         game.make_move(m);
 //!         game.history.push(m); // Keep track of the moves played
 //!
-//!         println!("Engine played {}", m.to_can());
+//!         println!("Engine played {}", m.to_lan());
 //!     },
 //!     None => {
 //!         println!("Engine could not find a move to play");

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -54,6 +54,7 @@ impl PieceChar for Piece {
             _   => EMPTY // FIXME
         }
     }
+
     fn to_char(&self) -> char {
         match *self {
             WHITE_PAWN   => 'P',

--- a/src/piece_move.rs
+++ b/src/piece_move.rs
@@ -67,7 +67,7 @@ impl PieceMove {
         PROMOTION_KINDS[(self.kind() & PROMOTION_KIND_MASK >> 2) as usize]
     }
 
-    pub fn to_can(self) -> String {
+    pub fn to_lan(self) -> String {
         self.to_string()
     }
 }

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -547,7 +547,7 @@ mod tests {
         for m in moves.iter() {
             game.make_move(*m);
             let fen = game.to_fen();
-            println!("{} {}", fen, m.to_can());
+            println!("{} {}", fen, m.to_lan());
             let copy = Game::from_fen(&fen);
             assert_eq!(copy.to_fen().as_str(), fen);
             assert_eq!(copy.positions.top().hash, game.positions.top().hash);
@@ -743,8 +743,8 @@ mod tests {
         let fen = "rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2";
         let mut game = Game::from_fen(fen);
 
-        let capture = game.move_from_can("e4d5");
-        let first_quiet_move = game.move_from_can("a2a3");
+        let capture = game.move_from_lan("e4d5");
+        let first_quiet_move = game.move_from_lan("a2a3");
 
         game.moves.clear();
 
@@ -765,15 +765,15 @@ mod tests {
         let fen = "rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 2";
         let mut game = Game::from_fen(fen);
 
-        let capture = game.move_from_can("e4d5");
-        let first_quiet_move = game.move_from_can("a2a3");
+        let capture = game.move_from_lan("e4d5");
+        let first_quiet_move = game.move_from_lan("a2a3");
 
-        let first_killer_move = game.move_from_can("f1b5");
+        let first_killer_move = game.move_from_lan("f1b5");
         game.moves.add_killer_move(first_killer_move);
 
         game.moves.clear();
 
-        let best_move = game.move_from_can("b1c3");
+        let best_move = game.move_from_lan("b1c3");
         game.moves.add_move(best_move);
 
         let mut n = 0;
@@ -796,12 +796,12 @@ mod tests {
         let fen = "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4";
         let mut game = Game::from_fen(fen);
 
-        let best_move     = game.move_from_can("b5a4");
-        let good_capture  = game.move_from_can("b5c6");
-        let bad_capture_1 = game.move_from_can("f3e5");
-        let bad_capture_2 = game.move_from_can("b5a6");
-        let quiet_move_1  = game.move_from_can("a2a3");
-        let killer_move_1 = game.move_from_can("b5c4");
+        let best_move     = game.move_from_lan("b5a4");
+        let good_capture  = game.move_from_lan("b5c6");
+        let bad_capture_1 = game.move_from_lan("f3e5");
+        let bad_capture_2 = game.move_from_lan("b5a6");
+        let quiet_move_1  = game.move_from_lan("a2a3");
+        let killer_move_1 = game.move_from_lan("b5c4");
 
         game.moves.add_killer_move(killer_move_1);
         game.moves.clear();
@@ -829,11 +829,11 @@ mod tests {
         let fen = "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4";
         let mut game = Game::from_fen(fen);
 
-        let good_capture  = game.move_from_can("b5c6");
-        let bad_capture_1 = game.move_from_can("f3e5");
-        let bad_capture_2 = game.move_from_can("b5a6");
-        let quiet_move_1  = game.move_from_can("a2a3");
-        let killer_move_1 = game.move_from_can("b5c4");
+        let good_capture  = game.move_from_lan("b5c6");
+        let bad_capture_1 = game.move_from_lan("f3e5");
+        let bad_capture_2 = game.move_from_lan("b5a6");
+        let quiet_move_1  = game.move_from_lan("a2a3");
+        let killer_move_1 = game.move_from_lan("b5c4");
 
         let best_move = bad_capture_2;
 

--- a/src/piece_move_notation.rs
+++ b/src/piece_move_notation.rs
@@ -1,3 +1,5 @@
+use regex::Regex;
+
 use attack::piece_attacks;
 use bitboard::BitboardExt;
 use color::*;
@@ -8,11 +10,18 @@ use piece::{PieceAttr, PieceChar};
 use piece_move::*;
 use square::*;
 use square::SquareExt;
+use search::Search;
+
+static RE_SAN: &str =
+    r"^(?P<piece>[NBRQK])?(?P<file>[a-h])?(?P<rank>[1-9])?(?P<capture>x)?(?P<to>[a-h][1-9])=?(?P<promotion>[KBRQ])?|(?P<queen>O-O-O)|(?P<king>O-O)";
 
 /// PieceMoveList generator
 pub trait PieceMoveNotation {
     /// Get move from the given CAN string
     fn move_from_can(&mut self, s: &str) -> PieceMove;
+
+    /// Get move from the given SAN string
+    fn move_from_san(&mut self, s: &str) -> Option<PieceMove>;
 
     /// Get SAN string from the given move
     fn move_to_san(&mut self, m: PieceMove) -> String;
@@ -60,6 +69,62 @@ impl PieceMoveNotation for Game {
         };
 
         PieceMove::new(from, to, mt)
+    }
+
+    fn move_from_san(&mut self, s: &str) -> Option<PieceMove> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(RE_SAN).unwrap();
+        }
+        let caps = RE.captures(s).unwrap();
+
+        let side = self.side();
+        if caps.name("queen").is_some() {
+            return Some(PieceMove::new(E1.flip(side), C1.flip(side), QUEEN_CASTLE));
+        }
+        if caps.name("king").is_some() {
+            return Some(PieceMove::new(E1.flip(side), G1.flip(side), KING_CASTLE));
+        }
+
+        if caps.name("to").is_none() {
+            return None;
+        }
+        let to = Square::from_coord(&caps["to"]);
+        for m in self.get_moves() {
+            if m.to() != to {
+                continue;
+            }
+
+            let p = self.board[m.from() as usize];
+            if let Some(piece) = caps.name("piece") {
+                if p.kind().to_char().to_string() != piece.as_str() {
+                    continue;
+                }
+            } else if p.kind() != PAWN {
+                continue;
+            }
+
+            if let Some(file) = caps.name("file") {
+                if m.from().file_to_char().to_string() != file.as_str() {
+                    continue;
+                }
+            }
+
+            if let Some(rank) = caps.name("rank") {
+                if m.from().rank_to_char().to_string() != rank.as_str() {
+                    continue;
+                }
+            }
+
+            if let Some(promotion) = caps.name("promotion") {
+                if m.promotion_kind().to_char().to_string() != promotion.as_str() {
+                    continue;
+                }
+            }
+
+            return Some(m);
+        }
+
+        None
     }
 
     // NOTE: this function assumes that the move has not been played yet
@@ -132,8 +197,35 @@ mod tests {
         let fen = "7k/3P1ppp/4PQ2/8/8/8/8/6RK w - - 0 1";
         let mut game = Game::from_fen(fen);
 
-        // NOTE: this move should really end with `#`, but this is done
-        // in `search::get_pv()`.
+        // NOTE: This move should end with `#` but this is added in `search::get_pv()`.
         assert_eq!(game.move_to_san(PieceMove::new(F6, G7, CAPTURE)), "Qxg7");
+    }
+
+    #[test]
+    fn test_move_from_san() {
+        let fen = "1q3rk1/Pbpp1p1p/2nb1n1Q/1p2p1pP/2NPP3/1B3N2/1PPB1PP1/R3K2R w KQ g6 0 25";
+        let mut game = Game::from_fen(fen);
+        assert_eq!(game.move_from_san("O-O"), Some(PieceMove::new(E1, G1, KING_CASTLE)));
+        assert_eq!(game.move_from_san("O-O-O"), Some(PieceMove::new(E1, C1, QUEEN_CASTLE)));
+        assert_eq!(game.move_from_san("g3"), Some(PieceMove::new(G2, G3, QUIET_MOVE)));
+        assert_eq!(game.move_from_san("Ng1"), Some(PieceMove::new(F3, G1, QUIET_MOVE)));
+        assert_eq!(game.move_from_san("Ng5"), Some(PieceMove::new(F3, G5, CAPTURE)));
+        assert_eq!(game.move_from_san("dxe5"), Some(PieceMove::new(D4, E5, CAPTURE)));
+        assert_eq!(game.move_from_san("Nfxe5"), Some(PieceMove::new(F3, E5, CAPTURE)));
+        assert_eq!(game.move_from_san("Ncxe5"), Some(PieceMove::new(C4, E5, CAPTURE)));
+        assert_eq!(game.move_from_san("a8Q"), Some(PieceMove::new(A7, A8, QUEEN_PROMOTION)));
+        assert_eq!(game.move_from_san("axb8N"), Some(PieceMove::new(A7, B8, KNIGHT_PROMOTION_CAPTURE)));
+        assert_eq!(game.move_from_san("g4"), Some(PieceMove::new(G2, G4, DOUBLE_PAWN_PUSH)));
+        assert_eq!(game.move_from_san("hxg6"), Some(PieceMove::new(H5, G6, EN_PASSANT)));
+        assert_eq!(game.move_from_san("hxg6e.p."), Some(PieceMove::new(H5, G6, EN_PASSANT)));
+        assert_eq!(game.move_from_san("Qg7"), Some(PieceMove::new(H6, G7, QUIET_MOVE)));
+        assert_eq!(game.move_from_san("Qxh7"), Some(PieceMove::new(H6, H7, CAPTURE)));
+        assert_eq!(game.move_from_san("Qg7!"), Some(PieceMove::new(H6, G7, QUIET_MOVE)));
+        assert_eq!(game.move_from_san("Qxh7!"), Some(PieceMove::new(H6, H7, CAPTURE)));
+
+        for m in game.get_moves() {
+            let san = game.move_to_san(m);
+            assert_eq!(game.move_from_san(&san), Some(m));
+        }
     }
 }

--- a/src/piece_move_notation.rs
+++ b/src/piece_move_notation.rs
@@ -12,9 +12,9 @@ use square::*;
 use square::SquareExt;
 use search::Search;
 
-static RE_LAN: &str = r"^(?P<from>[a-h][0-9])(?P<to>[a-h][0-9])(?P<promotion>[nbrq])?$";
+static RE_LAN: &str = r"^(?P<from>[a-h][1-8])(?P<to>[a-h][1-8])(?P<promotion>[nbrq])?$";
 static RE_SAN: &str = r"(?x)
-    ^(?P<piece>[NBRQK])?(?P<file>[a-h])?(?P<rank>[1-9])?(?P<capture>x)?(?P<to>[a-h][1-9])=?(?P<promotion>[KBRQ])?
+    ^(?P<piece>[NBRQK])?(?P<file>[a-h])?(?P<rank>[1-8])?(?P<capture>x)?(?P<to>[a-h][1-8])=?(?P<promotion>[KBRQ])?
     |(?P<queen>O-O-O)
     |(?P<king>O-O)";
 

--- a/src/piece_move_notation.rs
+++ b/src/piece_move_notation.rs
@@ -11,7 +11,7 @@ use square::SquareExt;
 
 /// PieceMoveList generator
 pub trait PieceMoveNotation {
-    /// Get move from the given SAN string
+    /// Get move from the given CAN string
     fn move_from_can(&mut self, s: &str) -> PieceMove;
 
     /// Get SAN string from the given move
@@ -19,13 +19,13 @@ pub trait PieceMoveNotation {
 }
 
 impl PieceMoveNotation for Game {
+    // TODO: Return Option<PieceMove>
     fn move_from_can(&mut self, s: &str) -> PieceMove {
         debug_assert!(s.len() == 4 || s.len() == 5);
 
         let side = self.side();
-        let (a, b) = s.split_at(2);
-        let from = Square::from_coord(String::from(a));
-        let to = Square::from_coord(String::from(b));
+        let from = Square::from_coord(&s[0..2]);
+        let to = Square::from_coord(&s[2..4]);
         let piece = self.board[from as usize];
         let capture = self.board[to as usize];
 

--- a/src/piece_move_notation.rs
+++ b/src/piece_move_notation.rs
@@ -17,10 +17,10 @@ static RE_SAN: &str =
 
 /// PieceMoveList generator
 pub trait PieceMoveNotation {
-    /// Get move from the given CAN string
+    /// Get move from the given CAN string (fast)
     fn move_from_can(&mut self, s: &str) -> PieceMove;
 
-    /// Get move from the given SAN string
+    /// Get move from the given SAN string (slow)
     fn move_from_san(&mut self, s: &str) -> Option<PieceMove>;
 
     /// Get SAN string from the given move
@@ -28,7 +28,6 @@ pub trait PieceMoveNotation {
 }
 
 impl PieceMoveNotation for Game {
-    // TODO: Return Option<PieceMove>
     fn move_from_can(&mut self, s: &str) -> PieceMove {
         debug_assert!(s.len() == 4 || s.len() == 5);
 

--- a/src/piece_move_notation.rs
+++ b/src/piece_move_notation.rs
@@ -88,7 +88,10 @@ impl PieceMoveNotation for Game {
         lazy_static! {
             static ref RE: Regex = Regex::new(RE_SAN).unwrap();
         }
-        let caps = RE.captures(s).unwrap();
+        let caps = match RE.captures(s) {
+            Some(caps) => caps,
+            None => return None,
+        };
 
         let side = self.side();
         if caps.name("queen").is_some() {
@@ -252,6 +255,7 @@ mod tests {
     fn test_move_from_san() {
         let fen = "1q3rk1/Pbpp1p1p/2nb1n1Q/1p2p1pP/2NPP3/1B3N2/1PPB1PP1/R3K2R w KQ g6 0 25";
         let mut game = Game::from_fen(fen);
+        assert_eq!(game.move_from_san("none"), None);
         assert_eq!(game.move_from_san("O-O"), Some(PieceMove::new(E1, G1, KING_CASTLE)));
         assert_eq!(game.move_from_san("O-O-O"), Some(PieceMove::new(E1, C1, QUEEN_CASTLE)));
         assert_eq!(game.move_from_san("g3"), Some(PieceMove::new(G2, G3, QUIET_MOVE)));

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -200,7 +200,7 @@ impl CLI {
 
     fn cmd_load(&mut self, args: &[&str]) {
         if args.len() == 1 {
-            print_error(format!("no subcommand given"));
+            print_error("no subcommand given");
             println!();
             self.cmd_load_usage();
             return;
@@ -212,14 +212,14 @@ impl CLI {
                 self.game.load_fen(&fen);
             },
             "pgn" => {
-                print_error(format!("not implemented yet")); // TODO
+                print_error("not implemented yet"); // TODO
                 println!();
             }
             "help" => {
                 self.cmd_load_usage();
             }
             _ => {
-                print_error(format!("unrecognized subcommand '{}'", args[1]));
+                print_error(&format!("unrecognized subcommand '{}'", args[1]));
                 println!();
                 self.cmd_load_usage();
             }
@@ -228,7 +228,7 @@ impl CLI {
 
     fn cmd_save(&mut self, args: &[&str]) {
         if args.len() == 1 {
-            print_error(format!("no subcommand given"));
+            print_error("no subcommand given");
             println!();
             self.cmd_save_usage();
             return;
@@ -242,7 +242,7 @@ impl CLI {
                 let starting_fen = self.game.starting_fen.clone();
 
                 if args.len() == 2 {
-                    print_error(format!("no filename given"));
+                    print_error("no filename given");
                     return;
                 }
                 let path = Path::new(args[2]);
@@ -317,7 +317,7 @@ impl CLI {
                 self.cmd_save_usage();
             }
             _ => {
-                print_error(format!("unrecognized subcommand '{}'", args[1]));
+                print_error(&format!("unrecognized subcommand '{}'", args[1]));
                 println!();
                 self.cmd_save_usage();
             }
@@ -326,7 +326,7 @@ impl CLI {
 
     fn cmd_config(&mut self, value: bool, args: &[&str]) {
         if args.len() != 2 {
-            print_error(format!("no subcommand given"));
+            print_error("no subcommand given");
             println!();
             self.cmd_config_usage(value);
             return;
@@ -360,7 +360,7 @@ impl CLI {
                 self.cmd_config_usage(value);
             }
             _ => {
-                print_error(format!("unrecognized subcommand '{}'", args[1]));
+                print_error(&format!("unrecognized subcommand '{}'", args[1]));
                 println!();
                 self.cmd_config_usage(value);
             }
@@ -469,7 +469,7 @@ impl CLI {
                 }
             }
             if !is_valid {
-                print_error(format!("move '{}' is not a valid move", args[1]));
+                print_error(&format!("move '{}' is not valid", args[1]));
                 return;
             }
 
@@ -492,7 +492,7 @@ impl CLI {
                 self.print_result(true);
             }
         } else {
-            print_error(format!("could not parse move '{}'", args[1]));
+            print_error(&format!("could not parse move '{}'", args[1]));
         }
     }
 
@@ -509,7 +509,7 @@ impl CLI {
         let mut nodes_count = 0u64;
 
         if args.len() != 2 {
-            print_error(format!("no depth given"));
+            print_error("no depth given");
             return;
         }
 
@@ -581,7 +581,7 @@ impl CLI {
         self.game.moves.skip_killers = true;
 
         if args.len() == 1 {
-            print_error(format!("no filename given"));
+            print_error("no filename given");
             return;
         }
         let path = Path::new(args[1]);
@@ -610,7 +610,7 @@ impl CLI {
 
     fn cmd_testsuite(&mut self, args: &[&str]) {
         if args.len() == 1 {
-            print_error(format!("no filename given"));
+            print_error("no filename given");
             return;
         }
         let time = if args.len() == 3 {
@@ -664,11 +664,11 @@ impl CLI {
     }
 
     fn cmd_error(&mut self, args: &[&str]) {
-        print_error(format!("unrecognized command '{}'", args[0]));
+        print_error(&format!("unrecognized command '{}'", args[0]));
     }
 }
 
-fn print_error(msg: String) {
+fn print_error(msg: &str) {
     println!("# {} {}", "error:".bold().red(), msg);
 }
 

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -65,7 +65,7 @@ impl CLI {
 
         loop {
             if let Some(helper) = rl.helper_mut() {
-                helper.move_params = self.game.get_moves();
+                helper.move_params = self.game.get_moves().into_iter().map(|m| m.to_can()).collect()
             }
 
             match rl.readline("> ") {

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -50,7 +50,7 @@ impl CLI {
             max_depth: (MAX_PLY - 10) as Depth,
             play_side: None,
             show_board: false,
-            show_san: false,
+            show_san: true,
         }
     }
 

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -67,7 +67,7 @@ impl CLI {
         loop {
             if let Some(helper) = rl.helper_mut() {
                 helper.move_params = self.game.get_moves().into_iter().
-                    map(|m| if self.show_san { self.game.move_to_san(m) } else { m.to_can() }).collect();
+                    map(|m| if self.show_san { self.game.move_to_san(m) } else { m.to_lan() }).collect();
             }
 
             match rl.readline("> ") {
@@ -402,7 +402,7 @@ impl CLI {
             println!();
         }
         if let Some(m) = r {
-            println!("{} move {}", c, if self.show_san { self.game.move_to_san(m) } else { m.to_can() });
+            println!("{} move {}", c, if self.show_san { self.game.move_to_san(m) } else { m.to_lan() });
 
             if play {
                 self.game.make_move(m);
@@ -522,11 +522,11 @@ impl CLI {
             //println!("{}", game.to_string());
             if !self.game.is_check(side) {
                 let r = self.game.perft(d);
-                println!("{} {}", if self.show_san { self.game.move_to_san(m) } else { m.to_can() }, r);
+                println!("{} {}", if self.show_san { self.game.move_to_san(m) } else { m.to_lan() }, r);
                 moves_count += 1;
                 nodes_count += r;
             } else {
-                //println!("{} (illegal)", m.to_can());
+                //println!("{} (illegal)", m.to_lan());
             }
             self.game.undo_move(m);
         }

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -518,15 +518,13 @@ impl CLI {
         let side = self.game.side();
         self.game.moves.clear();
         while let Some(m) = self.game.next_move() {
+            let move_str = if self.show_san { self.game.move_to_san(m) } else { m.to_lan() };
             self.game.make_move(m);
-            //println!("{}", game.to_string());
             if !self.game.is_check(side) {
                 let r = self.game.perft(d);
-                println!("{} {}", if self.show_san { self.game.move_to_san(m) } else { m.to_lan() }, r);
+                println!("{} {}", move_str, r);
                 moves_count += 1;
                 nodes_count += r;
-            } else {
-                //println!("{} (illegal)", m.to_lan());
             }
             self.game.undo_move(m);
         }
@@ -747,6 +745,14 @@ mod tests {
         // Undo 0 moves
         cli.cmd_undo();
 
+        assert!(true);
+    }
+
+    #[test]
+    fn test_divide() {
+        let mut cli = CLI::new();
+
+        cli.cmd_divide(&["divide", "2"]);
         assert!(true);
     }
 }

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -145,7 +145,7 @@ impl UCI {
         self.game.load_fen(&fen.join(" "));
 
         for s in moves {
-            let m = self.game.move_from_can(s);
+            let m = self.game.move_from_lan(s);
             self.game.make_move(m);
             self.game.history.push(m);
         }
@@ -165,7 +165,7 @@ impl UCI {
 
             if print_bestmove.load(Ordering::Relaxed) {
                 match res {
-                    Some(m) => println!("bestmove {}", m.to_can()),
+                    Some(m) => println!("bestmove {}", m.to_lan()),
                     None    => println!("bestmove 0000")
                 }
             }

--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -163,7 +163,7 @@ impl XBoard {
             return;
         }
 
-        let m = self.game.move_from_can(args[0]);
+        let m = self.game.move_from_lan(args[0]);
         self.game.make_move(m);
         self.game.history.push(m);
 
@@ -188,7 +188,7 @@ impl XBoard {
                 self.game.make_move(m);
                 self.game.history.push(m);
 
-                println!("move {}", m.to_can());
+                println!("move {}", m.to_lan());
             }
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ pub trait Search {
     fn quiescence(&mut self, alpha: Score, beta: Score, depth: Depth, ply: usize) -> Score;
 
     fn is_mate(&mut self) -> bool;
-    fn get_moves(&mut self) -> Vec<String>;
+    fn get_moves(&mut self) -> Vec<PieceMove>;
 }
 
 trait SearchExt {
@@ -540,14 +540,14 @@ impl Search for Game {
         true
     }
 
-    fn get_moves(&mut self) -> Vec<String> {
+    fn get_moves(&mut self) -> Vec<PieceMove> {
         let mut res = Vec::new();
         let side = self.side();
         self.moves.clear();
         while let Some(m) = self.next_move() {
             self.make_move(m);
             if !self.is_check(side) {
-                res.push(m.to_can());
+                res.push(m);
             }
             self.undo_move(m);
         }
@@ -895,6 +895,6 @@ mod tests {
 
         // Initial position
         game.load_fen("8/8/8/8/r7/1k6/8/K7 w - - 0 1");
-        assert_eq!(game.get_moves(), vec!["a1b1"]);
+        assert_eq!(game.get_moves(), vec![PieceMove::new(A1, B1, QUIET_MOVE)])
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -565,7 +565,7 @@ impl SearchExt for Game {
 
     fn print_thinking_init(&self) {
         if self.protocol != Protocol::UCI {
-            println!("  {:>3}  {:>5}  {:>6}  {:>9}  {}", "dep", "score", "time", "nodes", "pv");
+            println!("  {:>3}  {:>5}  {:>6}  {:>9}  {}", "ply", "score", "time", "nodes", "pv");
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -619,7 +619,7 @@ impl SearchExt for Game {
             let cur = if is_san_format {
                 self.move_to_san(m)
             } else {
-                m.to_can()
+                m.to_lan()
             };
             self.make_move(m);
 
@@ -753,7 +753,7 @@ mod tests {
         let mut game = Game::from_fen("8/pp3p1k/2p2q1p/3r1P1Q/5R2/7P/P1P2P2/7K w - - 1 30");
         let moves = vec!["h5e2", "f6e5", "e2h5", "e5f6", "h5e2", "d5e5", "e2d3", "e5d5", "d3e2"];
         for s in moves {
-            let m = game.move_from_can(s);
+            let m = game.move_from_lan(s);
             game.make_move(m);
             game.history.push(m);
         }

--- a/src/square.rs
+++ b/src/square.rs
@@ -71,7 +71,7 @@ pub const H8: Square = 63;
 pub const OUT: Square = 64;
 
 pub trait SquareExt {
-    fn from_coord(s: String) -> Self;
+    fn from_coord(s: &str) -> Self;
     fn to_coord(&self) -> String;
     fn file_to_char(&self) -> char;
     fn rank_to_char(&self) -> char;
@@ -81,7 +81,7 @@ pub trait SquareExt {
 }
 
 impl SquareExt for Square {
-    fn from_coord(s: String) -> Self {
+    fn from_coord(s: &str) -> Self {
         let bytes = s.as_bytes();
 
         ((bytes[0] - b'a') + 8 * (bytes[1] - b'1')) as Square
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_from_coord() {
-        let sq: Square = SquareExt::from_coord("e2".to_string());
+        let sq: Square = SquareExt::from_coord("e2");
         assert_eq!(sq, E2);
     }
 


### PR DESCRIPTION
Parsing moves in SAN format with a regex is much slower than with moves in LAN format, but it's more pleasant in the CLI against humans.

The CLI will now default to SAN format and an option has been added to switch back to LAN format.