### PR TITLE
Speed up large transposition table creations

### DIFF
--- a/benches/littlewing.rs
+++ b/benches/littlewing.rs
@@ -113,3 +113,37 @@ fn bench_move_from_san(b: &mut Bencher) {
         game.move_from_san("e4");
     });
 }
+
+#[bench]
+fn bench_tt_16mb_get(b: &mut Bencher) {
+    let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+    let m = game.move_from_lan("e2e4");
+    game.tt_resize(16 << 20); // 16 MB
+    game.search(1..5);
+    game.make_move(m);
+    let hash = game.positions.top().hash;
+    b.iter(|| {
+        if let Some(t) = game.tt.get(hash) {
+            t.score()
+        } else {
+            0
+        }
+    })
+}
+
+#[bench]
+fn bench_tt_256mb_get(b: &mut Bencher) {
+    let mut game = Game::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+    let m = game.move_from_lan("e2e4");
+    game.tt_resize(256 << 20); // 256 MB
+    game.search(1..5);
+    game.make_move(m);
+    let hash = game.positions.top().hash;
+    b.iter(|| {
+        if let Some(t) = game.tt.get(hash) {
+            t.score()
+        } else {
+            0
+        }
+    })
+}

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -82,13 +82,8 @@ impl TranspositionTable {
     }
 
     pub fn clear(&mut self) {
-        {
-            let h = self.entries.get();
-            let n = self.len();
-            for i in 0..n {
-                h[i] = Transposition::new_null();
-            }
-        }
+        let n = self.len();
+        self.entries = Arc::new(SharedTable::with_capacity(n));
         self.clear_stats();
     }
 


### PR DESCRIPTION
An empty transposition is equivalent in memory to a 128 bits unsigned integer, and it's much faster to create a boxed slice of integers on the heap than transpositions.