### PR TITLE
Remove time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ rand = "0.7"
 rand_xorshift = "0.2"
 regex = "1.0"
 rustyline = "5.0"
-time = "0.1"
 
 [badges]
 travis-ci = { repository = "vinc/littlewing" }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,12 +1,11 @@
-use time::precise_time_s;
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 #[derive(Clone)]
 pub struct Clock {
     pub polling_nodes_count: u64,
-    pub started_at: u64,
+    pub started_at: Instant,
     moves_level: u16,
     moves_remaining: u16,
     time_remaining: u64,
@@ -19,7 +18,7 @@ impl Clock {
     pub fn new(moves: u16, time: u64) -> Clock {
         Clock {
             polling_nodes_count: 100,
-            started_at: 0,
+            started_at: Instant::now(),
             moves_level: moves,
             moves_remaining: moves,
             time_remaining: time,
@@ -32,7 +31,7 @@ impl Clock {
     pub fn start(&mut self, ply: usize) {
         self.is_finished.store(false, Ordering::Relaxed);
         self.last_nodes_count = 0;
-        self.started_at = (precise_time_s() * 1000.0) as u64;
+        self.started_at = Instant::now();
 
         // The UCI protocol gives the number of remaining moves before each
         // search but XBoard doesn't so we need to calculate it based on moves
@@ -61,9 +60,7 @@ impl Clock {
     }
 
     pub fn elapsed_time(&self) -> u64 {
-        let now = (precise_time_s() * 1000.0) as u64;
-
-        now - self.started_at
+        self.started_at.elapsed().as_millis() as u64
     }
 
     pub fn poll(&mut self, nodes_count: u64) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ extern crate rand;
 extern crate rand_xorshift;
 extern crate regex;
 extern crate rustyline;
-extern crate time;
 
 mod attack;
 mod board;

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -4,13 +4,13 @@ use rustyline::hint::Hinter;
 use rustyline::highlight::Highlighter;
 use rustyline::completion::Completer;
 use rustyline::error::ReadlineError;
-use time::precise_time_s;
 
 use std::io;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 use std::error::Error;
 
 use version;
@@ -572,10 +572,9 @@ impl CLI {
         self.game.moves.skip_killers = true;
 
         loop {
-            let started_at = precise_time_s();
+            let started_at = Instant::now();
             let n = self.game.perft(depth);
-            let ended_at = precise_time_s();
-            let s = ended_at - started_at;
+            let s = started_at.elapsed().as_secs_f64();
             let nps = (n as f64) / s;
             println!("perft {} -> {} ({:.2} s, {:.2e} nps)", depth, n, s, nps);
 


### PR DESCRIPTION
The features used in the `time` crate can be replaced by `std::time`.