### PR TITLE
Fix invalid claim in short games

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -214,9 +214,8 @@ impl Search for Game {
                 self.undo_move(m);
             }
 
-            // Save the best move only if we found one and if we still have
-            // some time left after the search at this depth.
-            if !best_moves[depth as usize].is_null() && !self.clock.poll(self.nodes_count) {
+            // Save the best move
+            if !best_moves[depth as usize].is_null() && (depth == 1 || !self.clock.poll(self.nodes_count)) {
                 best_move = best_moves[depth as usize];
                 best_score = best_scores[depth as usize];
 


### PR DESCRIPTION
In some short 10s games the engine would sometimes claim a draw when it found no moves because it didn't have time to finish the first depth iteration.

```
Little Wing v0.7.0-10-g4ccca7e  1995    3    3 54997   38%  2098   11%
Little Wing v0.7.0              1991    3    3 54933   37%  2098   11%
```