### PR TITLE
Fix UCI issue with PV after draw

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -678,13 +678,17 @@ impl SearchExt for Game {
             };
             self.make_move(m);
 
-            let pv = &self.get_pv(depth - 1);
-            let sep = if is_san_format && self.is_check(side ^ 1) {
-                if pv == "#" { "" } else { "+ " }
+            if self.positions.is_draw() {
+                res.push(format!("{}", cur));
             } else {
-                " "
-            };
-            res.push(format!("{}{}{}", cur, sep, pv));
+                let pv = &self.get_pv(depth - 1);
+                let sep = if is_san_format && self.is_check(side ^ 1) {
+                    if pv == "#" { "" } else { "+ " }
+                } else {
+                    " "
+                };
+                res.push(format!("{}{}{}", cur, sep, pv));
+            }
 
             self.undo_move(m);
         } else if self.is_check(side) {


### PR DESCRIPTION
This PR fixes the following kind of warnings when using `fastchess` (instead of `cutechess-cli`):

```
Warning; PV continues after threefold repetition - move g2g1 from Little Wing v0.7.0-10-g8392343
Info; info depth 9 score cp 0 time 116 nodes 142233 pv g2g1 f4h3 g1g2 h3f4 g2g1 f4h3 g1g2 h3f4 g2g1
Position; startpos
Moves; e2e4 e7e5 g1f3 b8c6 f1c4 g8f6 d2d3 f8e7 e1g1 d7d6 a2a4 c8g4 c2c3 e8g8 f1e1 d6d5 e4d5 f6d5 d1b3 g4f3 g2f3 c6a5 b3a2 d5b6 b1d2 d8d6 e1e4 d6f6 c4b3 f6g6 g1h1 e7c5 d3d4 e5d4 c3d4 c5d6 b3d1 g6h5 d2f1 f8e8 c1d2 a5c4 e4e8 a8e8 d2c3 h5f5 a2b3 f5d3 h1g2 b6d5 b3b5 d5f4
```