### PR TITLE
Use safe lockless transposition table

### DIFF
--- a/src/piece_move.rs
+++ b/src/piece_move.rs
@@ -72,6 +72,14 @@ impl PieceMove {
     pub fn to_lan(self) -> String {
         self.to_string()
     }
+
+    pub fn to_u16(self) -> u16 {
+        self.0
+    }
+
+    pub fn from_u16(value: u16) -> Self {
+        Self(value)
+    }
 }
 
 impl fmt::Display for PieceMove {

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -1,4 +1,5 @@
 use std::prelude::v1::*;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::common::*;
 use crate::piece_move::PieceMove;
@@ -11,72 +12,168 @@ pub enum Bound {
     Upper
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Transposition {
-    hash: u64,            // 64 bits => 8 bytes
-    best_move: PieceMove, // 16 bits => 2 bytes
-    score: Score,         // 16 bits => 2 bytes
-    depth: Depth,         //  8 bits => 1 bytes
-    bound: Bound,         //  8 bits => 1 bytes
-    age: u8,              //  8 bits => 1 bytes
+impl Bound {
+    fn from_u8(n: u8) -> Bound {
+        match n {
+            0 => Bound::Exact,
+            1 => Bound::Lower,
+            2 => Bound::Upper,
+            _ => Bound::Exact
+        }
+    }
+}
 
-    // Total: 16 bytes
-    //
-    // NOTE: `depth` will never go above MAX_PLY, which is 128 so we can store
-    // it as `i8`.
-    //
-    // TODO: we don't need to store the whole hash as the first part is the
-    // index of the entry: `entries[hash % size]`
+#[derive(Debug)]
+pub struct Transposition {
+    hash: AtomicU64,
+    data: AtomicU64
 }
 
 impl Transposition {
-    pub fn new(hash: u64, depth: Depth, score: Score, best_move: PieceMove, bound: Bound, age: u8) -> Transposition {
-        Transposition { hash, depth, score, best_move, bound, age }
+    pub const fn new_null() -> Transposition {
+        Transposition {
+            hash: AtomicU64::new(0),
+            data: AtomicU64::new(0)
+        }
     }
 
-    pub fn new_null() -> Transposition {
-        Transposition::new(0, 0, 0, PieceMove::new_null(), Bound::Exact, 0)
+    pub fn new(hash: u64, depth: Depth, score: Score, best_move: PieceMove, bound: Bound, age: u8) -> Transposition {
+        let entry = Transposition::new_null();
+        entry.store(hash, depth, score, best_move, bound, age);
+        entry
+    }
+
+    pub fn store(&self, hash: u64, depth: Depth, score: Score, best_move: PieceMove, bound: Bound, age: u8) {
+        let a = ((age as u64) & 0xFF) << 8;
+        let b = ((bound as u8) as u64 & 0xFF) << 16;
+        let d = ((depth as u8) as u64 & 0xFF) << 24;
+        let s = ((score as u16) as u64 & 0xFFFF) << 32;
+        let m = (best_move.to_u16() as u64 & 0xFFFF) << 48;
+        let data = a | b | d | s | m;
+        self.data.store(data, Ordering::Release);
+        self.hash.store(hash ^ data, Ordering::Release);
     }
 
     pub fn hash(&self) -> u64 {
-        self.hash
+        self.hash.load(Ordering::Acquire)
     }
 
-    pub fn depth(&self) -> Depth {
-        self.depth
+    pub fn data(&self) -> u64 {
+        self.data.load(Ordering::Acquire)
     }
 
-    pub fn score(&self) -> Score {
-        self.score
-    }
-
-    pub fn best_move(&self) -> PieceMove {
-        self.best_move
-    }
-
-    pub fn bound(&self) -> Bound {
-        self.bound
+    pub fn hash_and_data(&self) -> (u64, u64) {
+        loop {
+            let hash_before = self.hash.load(Ordering::Acquire);
+            let data = self.data.load(Ordering::Acquire);
+            let hash_after = self.hash.load(Ordering::Acquire);
+            if hash_before == hash_after {
+                return (hash_after, data);
+            }
+        }
     }
 
     pub fn age(&self) -> u8 {
-        self.age
+        ((self.data() >> 8) & 0xFF) as u8
+    }
+
+    pub fn bound(&self) -> Bound {
+        Bound::from_u8(((self.data() >> 16) & 0xFF) as u8)
+    }
+
+    pub fn depth(&self) -> Depth {
+        (((self.data() >> 24) & 0xFF) as u8) as Depth
+    }
+
+    pub fn score(&self) -> Score {
+        (((self.data() >> 32) & 0xFFFF) as u16) as Score
+    }
+
+    pub fn best_move(&self) -> PieceMove {
+        PieceMove::from_u16(((self.data() >> 48) & 0xFFFF) as u16)
+    }
+
+    pub fn is_null(&self) -> bool {
+        self.best_move().is_null()
+    }
+}
+
+impl Clone for Transposition {
+    fn clone(&self) -> Self {
+        Transposition {
+            hash: AtomicU64::new(self.hash()),
+            data: AtomicU64::new(self.data()),
+        }
+    }
+}
+
+impl PartialEq for Transposition {
+    fn eq(&self, other: &Self) -> bool {
+        let h1 = self.hash.load(Ordering::Relaxed);
+        let h2 = other.hash.load(Ordering::Relaxed);
+        let d1 = self.data.load(Ordering::Relaxed);
+        let d2 = other.data.load(Ordering::Relaxed);
+        h1 == h2 && d1 == d2
+    }
+}
+
+impl Eq for Transposition {}
+
+impl Default for Transposition {
+    fn default() -> Self {
+        Transposition::new_null()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-
     use super::*;
     use crate::piece_move::PieceMove;
+    use crate::square::*;
 
     #[test]
     fn test_size_of_transposition() {
-        assert_eq!(mem::size_of::<u64>(),       8); // Hash
-        assert_eq!(mem::size_of::<Score>(),     2); // Score
-        assert_eq!(mem::size_of::<PieceMove>(), 2); // PieceMove
-        assert_eq!(mem::size_of::<u8>(),        1); // Depth
+        assert_eq!(core::mem::size_of::<Transposition>(), 16);
+    }
 
-        assert_eq!(mem::size_of::<Transposition>(), 16);
+    #[test]
+    fn test_new() {
+        let hash = 0x1234_5678_9ABC_DEF0;
+        let depth: Depth = 8;
+        let score: Score = -231;
+        let best_move = PieceMove::new(E2, E4, DOUBLE_PAWN_PUSH);
+        let bound = Bound::Lower;
+        let age = 17;
+
+        let entry = Transposition::new(hash, depth, score, best_move, bound, age);
+
+        let (hash_word, data_word) = entry.hash_and_data();
+        assert_eq!(hash_word ^ data_word, hash);
+        assert_eq!(entry.depth(), depth);
+        assert_eq!(entry.score(), score);
+        assert_eq!(entry.best_move(), best_move);
+        assert_eq!(entry.bound(), bound);
+        assert_eq!(entry.age(), age);
+    }
+
+    #[test]
+    fn test_store() {
+        let hash = 0x1234_5678_9ABC_DEF0;
+        let depth: Depth = 8;
+        let score: Score = -231;
+        let best_move = PieceMove::new(E2, E4, DOUBLE_PAWN_PUSH);
+        let bound = Bound::Lower;
+        let age = 17;
+
+        let entry = Transposition::new_null();
+        entry.store(hash, depth, score, best_move, bound, age);
+
+        let (hash_word, data_word) = entry.hash_and_data();
+        assert_eq!(hash_word ^ data_word, hash);
+        assert_eq!(entry.depth(), depth);
+        assert_eq!(entry.score(), score);
+        assert_eq!(entry.best_move(), best_move);
+        assert_eq!(entry.bound(), bound);
+        assert_eq!(entry.age(), age);
     }
 }

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -1,5 +1,4 @@
 use std::prelude::v1::*;
-use std::cell::UnsafeCell;
 use std::mem;
 use std::sync::Arc;
 
@@ -52,13 +51,15 @@ impl TranspositionTable {
         // TODO: how faster would it be to just also return null move?
         if t.best_move().is_null() {
             None
-        } else if t.hash() != hash {
-            self.stats_collisions += 1;
-            None
         } else {
-            debug_assert_eq!(t.hash(), hash);
-            self.stats_hits += 1;
-            Some(t)
+            let (hash_word, data_word) = t.hash_and_data();
+            if hash_word ^ data_word != hash {
+                self.stats_collisions += 1;
+                None
+            } else {
+                self.stats_hits += 1;
+                Some(t)
+            }
         }
     }
 
@@ -71,8 +72,7 @@ impl TranspositionTable {
         // Always replace entries from previous searches (entry.age < age)
         // but use depth preferred replacement strategy for the current search.
         if age > h[k].age() || (age == 0 && h[k].age() > 0) || depth >= h[k].depth() {
-            let t = Transposition::new(hash, depth, score, best_move, bound, age);
-            h[k] = t;
+            h[k].store(hash, depth, score, best_move, bound, age);
             self.stats_inserts += 1;
         }
     }
@@ -154,31 +154,18 @@ impl TranspositionTable {
 }
 
 pub struct SharedTable {
-    inner: UnsafeCell<Box<[Transposition]>>
+    inner: Box<[Transposition]>,
 }
-
-// Tell the compiler than the transposition table can be shared between
-// threads inside an `Arc`, even if it's not really safe at all in reality :)
-unsafe impl Sync for SharedTable {}
 
 impl SharedTable {
     pub fn with_capacity(capacity: usize) -> SharedTable {
         SharedTable {
-            // NOTE: Transmuting a boxed slice of zeroed 128 bit integers into
-            // empty transpositions is much faster than creating a boxed slice
-            // of transitions directly.
-            // inner: UnsafeCell::new(vec![Transposition::new_null(); capacity].into_boxed_slice())
-            inner: UnsafeCell::new(unsafe {
-                mem::transmute::<Box<[u128]>, Box<[Transposition]>>(
-                    vec![0u128; capacity].into_boxed_slice()
-                )
-            })
+            inner: vec![Transposition::new_null(); capacity].into_boxed_slice()
         }
     }
 
-    // FIXME: mutable borrow from immutable input
-    pub fn get(&self) -> &mut [Transposition] {
-        unsafe { &mut *self.inner.get() }
+    pub fn get(&self) -> &[Transposition] {
+        &self.inner
     }
 }
 


### PR DESCRIPTION
This PR replaces the unsafe shared transposition table with a safe lockless version using two atomics for `data` and `hash xor data` to detect memory corruption.

See here for the paper describing the idea: https://craftychess.com/hyatt/hashing.html