### PR TITLE
Add history heuristic

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -164,6 +164,8 @@ pub const MAX_KILLERS: usize = 2;
 
 pub const TT_SIZE: usize = 8 << 20; // 8 Mb
 
+pub const HH_MAX: Score = 16 << 10;
+
 pub const XSHIFTS: [Shift; 2] = [LEFT, RIGHT];
 pub const YSHIFTS: [Shift; 2] = [UP, DOWN];
 pub const END_FILES: [Bitboard; 2] = [FILE_A, FILE_H];

--- a/src/game.rs
+++ b/src/game.rs
@@ -83,6 +83,7 @@ impl Game {
         self.board = [EMPTY; 64];
         self.moves.clear_all();
         self.positions.clear();
+        self.clear_history();
         self.plies.clear();
         //self.tt.clear();
     }
@@ -110,6 +111,10 @@ impl Game {
         let b = m.from() as usize;
         let c = self.side() as usize;
         self.history[c][b][a] = bonus;
+    }
+
+    pub fn clear_history(&mut self) {
+        self.history = [[[0; 64]; 64]; 2];
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -33,9 +33,9 @@ pub struct Game {
     pub bitboards: [Bitboard; 14],
     pub board: [Piece; 64],
     pub moves: PieceMoveList,
+    pub plies: Vec<PieceMove>,
     pub positions: Positions,
     pub zobrist: Zobrist,
-    pub history: Vec<PieceMove>,
     pub tt: TranspositionTable
 }
 
@@ -57,9 +57,9 @@ impl Game {
             bitboards: [0; 14],
             board: [EMPTY; 64],
             moves: PieceMoveList::new(),
+            plies: Vec::new(),
             positions: Positions::new(),
             zobrist: Zobrist::new(),
-            history: Vec::new(),
             tt: TranspositionTable::with_memory(TT_SIZE)
         }
     }
@@ -81,7 +81,7 @@ impl Game {
         self.board = [EMPTY; 64];
         self.moves.clear_all();
         self.positions.clear();
-        self.history.clear();
+        self.plies.clear();
         //self.tt.clear();
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -7,6 +7,7 @@ use crate::piece::*;
 use crate::common::*;
 use crate::bitboard::Bitboard;
 use crate::clock::Clock;
+use crate::history::HistoryHeuristic;
 use crate::piece_move::PieceMove;
 use crate::piece_move_list::PieceMoveList;
 use crate::positions::Positions;
@@ -97,24 +98,6 @@ impl Game {
     /// Get the current side color
     pub fn side(&self) -> Color {
         self.positions.top().side
-    }
-
-    pub fn get_history(&self, m: PieceMove) -> Score {
-        let a = m.to() as usize;
-        let b = m.from() as usize;
-        let c = self.side() as usize;
-        self.history[c][b][a]
-    }
-
-    pub fn set_history(&mut self, m: PieceMove, bonus: Score) {
-        let a = m.to() as usize;
-        let b = m.from() as usize;
-        let c = self.side() as usize;
-        self.history[c][b][a] = bonus;
-    }
-
-    pub fn clear_history(&mut self) {
-        self.history = [[[0; 64]; 64]; 2];
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -34,6 +34,7 @@ pub struct Game {
     pub board: [Piece; 64],
     pub moves: PieceMoveList,
     pub plies: Vec<PieceMove>,
+    pub history: [[[Score; 64]; 64]; 2],
     pub positions: Positions,
     pub zobrist: Zobrist,
     pub tt: TranspositionTable
@@ -58,6 +59,7 @@ impl Game {
             board: [EMPTY; 64],
             moves: PieceMoveList::new(),
             plies: Vec::new(),
+            history: [[[0; 64]; 64]; 2],
             positions: Positions::new(),
             zobrist: Zobrist::new(),
             tt: TranspositionTable::with_memory(TT_SIZE)
@@ -94,6 +96,20 @@ impl Game {
     /// Get the current side color
     pub fn side(&self) -> Color {
         self.positions.top().side
+    }
+
+    pub fn get_history(&self, m: PieceMove) -> Score {
+        let a = m.to() as usize;
+        let b = m.from() as usize;
+        let c = self.side() as usize;
+        self.history[c][b][a]
+    }
+
+    pub fn set_history(&mut self, m: PieceMove, bonus: Score) {
+        let a = m.to() as usize;
+        let b = m.from() as usize;
+        let c = self.side() as usize;
+        self.history[c][b][a] = bonus;
     }
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,21 +5,23 @@ use crate::game::Game;
 use crate::piece_move::PieceMove;
 
 // TODO: Tune this
-const HH_BONUS_SCALE: Score = 300;
-const HH_BONUS_OFFSET: Score = 250;
-const HH_BONUS_CLAMP: Score = HH_MAX;
+const HH_BONUS_QUADRA: Score = 16;
+const HH_BONUS_LINEAR: Score = 128;
+const HH_BONUS_OFFSET: Score = -256;
+const HH_BONUS_CLAMP: Score = HH_MAX / 4;
 
-// TODO: Tune this
-const HH_MALUS_SCALE: Score = 300;
-const HH_MALUS_OFFSET: Score = 250;
-const HH_MALUS_CLAMP: Score = HH_MAX;
+// TODO: Use separate values
+const HH_MALUS_QUADRA: Score = HH_BONUS_QUADRA;
+const HH_MALUS_LINEAR: Score = HH_BONUS_LINEAR;
+const HH_MALUS_OFFSET: Score = HH_BONUS_OFFSET;
+//const HH_MALUS_CLAMP: Score = HH_BONUS_CLAMP;
 
 pub trait HistoryHeuristic {
     fn clear_history(&mut self);
     fn get_history(&self, m: PieceMove) -> Score;
+    fn set_history(&mut self, m: PieceMove, s: Score);
     fn inc_history(&mut self, m: PieceMove, d: Depth);
     fn dec_history(&mut self, m: PieceMove, d: Depth);
-    fn set_history(&mut self, m: PieceMove, s: Score);
 }
 
 impl HistoryHeuristic for Game {
@@ -34,46 +36,92 @@ impl HistoryHeuristic for Game {
         self.history[c][b][a]
     }
 
-    fn inc_history(&mut self, m: PieceMove, d: Depth) {
-        let d = d as i32;
-        let x = HH_BONUS_SCALE as i32;
-        let y = HH_BONUS_OFFSET as i32;
-        let z = HH_BONUS_CLAMP as i32;
-        let bonus = (d * x - y).clamp(0, z);
-        //let bonus = (d * d).min(z);
-
+    fn set_history(&mut self, m: PieceMove, s: Score) {
         // Gravity formula
+        let val = s as i32;
+        let max = HH_MAX as i32;
         let old = self.get_history(m) as i32;
-        let new = old + bonus - old * bonus / (HH_MAX as i32);
-        debug_assert!(new < Score::MAX as i32);
-        debug_assert!(new <= HH_MAX as i32);
-
-        self.set_history(m, new as Score);
-    }
-
-    fn dec_history(&mut self, m: PieceMove, d: Depth) {
-        let d = d as i32;
-        let x = HH_MALUS_SCALE as i32;
-        let y = HH_MALUS_OFFSET as i32;
-        let z = HH_MALUS_CLAMP as i32;
-        let malus = -(d * x - y).clamp(0, z);
-        //let malus = -(d * d).min(z);
-
-        // Gravity formula
-        let old = self.get_history(m) as i32;
-        let new = old + malus - old * malus.abs() / (HH_MAX as i32);
+        let new = old + val - old * val.abs() / max;
         debug_assert!(new < Score::MAX as i32);
         debug_assert!(new > Score::MIN as i32);
         debug_assert!(new <= HH_MAX as i32);
         debug_assert!(new >= -HH_MAX as i32);
-        
-        self.set_history(m, new as Score);
-    }
 
-    fn set_history(&mut self, m: PieceMove, s: Score) {
         let a = m.to() as usize;
         let b = m.from() as usize;
         let c = self.side() as usize;
-        self.history[c][b][a] = s;
+        self.history[c][b][a] = new as Score;
+    }
+
+    fn inc_history(&mut self, m: PieceMove, d: Depth) {
+        let s = delta(d, HH_BONUS_QUADRA, HH_BONUS_LINEAR, HH_BONUS_OFFSET);
+        self.set_history(m, s);
+    }
+
+    fn dec_history(&mut self, m: PieceMove, d: Depth) {
+        let s = -delta(d, HH_MALUS_QUADRA, HH_MALUS_LINEAR, HH_MALUS_OFFSET);
+        self.set_history(m, s);
+    }
+}
+
+fn delta(depth: Depth, quadra: Score, linear: Score, offset: Score) -> Score {
+    let d = depth as i32;
+    let x = quadra as i32;
+    let y = linear as i32;
+    let z = offset as i32;
+
+    (x * d * d + y * d + z).clamp(0, HH_BONUS_CLAMP as i32) as Score
+}
+
+#[cfg(test)]
+mod tests {
+    use std::prelude::v1::*;
+    use crate::common::*;
+    use crate::fen::FEN;
+    use crate::game::Game;
+    use crate::piece_move_notation::PieceMoveNotation;
+    use super::*;
+
+    #[test]
+    fn test_delta() {
+        let mut game = Game::new();
+        game.load_fen(DEFAULT_FEN).unwrap();
+
+        let bonuses = [0, 64, 272, 512, 784, 1088, 1424, 1792, 2192, 2624];
+        for (depth, bonus) in bonuses.iter().enumerate() {
+            assert_eq!(delta((depth + 1) as Depth, 16, 128, -256), *bonus);
+        }
+    }
+
+    #[test]
+    fn test_update_history() {
+        let mut game = Game::new();
+        game.load_fen(DEFAULT_FEN).unwrap();
+        let m = game.move_from_lan("e2e4");
+        assert_eq!(game.get_history(m), 0);
+
+        for value in [512, 1008, 1489, 1955, 2406, 2843] {
+            game.set_history(m, 512);
+            assert_eq!(game.get_history(m), value);
+        }
+
+        for value in [2243, 1661, 1098, 552, 23, -489] {
+            game.set_history(m, -512);
+            assert_eq!(game.get_history(m), value);
+        }
+    }
+
+    #[test]
+    fn test_clear_history() {
+        let mut game = Game::new();
+        game.load_fen(DEFAULT_FEN).unwrap();
+        let m = game.move_from_lan("e2e4");
+        assert_eq!(game.get_history(m), 0);
+
+        game.set_history(m, 512);
+        assert_eq!(game.get_history(m), 512);
+
+        game.clear_history();
+        assert_eq!(game.get_history(m), 0);
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,79 @@
+use std::prelude::v1::*;
+
+use crate::common::*;
+use crate::game::Game;
+use crate::piece_move::PieceMove;
+
+// TODO: Tune this
+const HH_BONUS_SCALE: Score = 300;
+const HH_BONUS_OFFSET: Score = 250;
+const HH_BONUS_CLAMP: Score = HH_MAX;
+
+// TODO: Tune this
+const HH_MALUS_SCALE: Score = 300;
+const HH_MALUS_OFFSET: Score = 250;
+const HH_MALUS_CLAMP: Score = HH_MAX;
+
+pub trait HistoryHeuristic {
+    fn clear_history(&mut self);
+    fn get_history(&self, m: PieceMove) -> Score;
+    fn inc_history(&mut self, m: PieceMove, d: Depth);
+    fn dec_history(&mut self, m: PieceMove, d: Depth);
+    fn set_history(&mut self, m: PieceMove, s: Score);
+}
+
+impl HistoryHeuristic for Game {
+    fn clear_history(&mut self) {
+        self.history = [[[0; 64]; 64]; 2];
+    }
+
+    fn get_history(&self, m: PieceMove) -> Score {
+        let a = m.to() as usize;
+        let b = m.from() as usize;
+        let c = self.side() as usize;
+        self.history[c][b][a]
+    }
+
+    fn inc_history(&mut self, m: PieceMove, d: Depth) {
+        let d = d as i32;
+        let x = HH_BONUS_SCALE as i32;
+        let y = HH_BONUS_OFFSET as i32;
+        let z = HH_BONUS_CLAMP as i32;
+        let bonus = (d * x - y).clamp(0, z);
+        //let bonus = (d * d).min(z);
+
+        // Gravity formula
+        let old = self.get_history(m) as i32;
+        let new = old + bonus - old * bonus / (HH_MAX as i32);
+        debug_assert!(new < Score::MAX as i32);
+        debug_assert!(new <= HH_MAX as i32);
+
+        self.set_history(m, new as Score);
+    }
+
+    fn dec_history(&mut self, m: PieceMove, d: Depth) {
+        let d = d as i32;
+        let x = HH_MALUS_SCALE as i32;
+        let y = HH_MALUS_OFFSET as i32;
+        let z = HH_MALUS_CLAMP as i32;
+        let malus = -(d * x - y).clamp(0, z);
+        //let malus = -(d * d).min(z);
+
+        // Gravity formula
+        let old = self.get_history(m) as i32;
+        let new = old + malus - old * malus.abs() / (HH_MAX as i32);
+        debug_assert!(new < Score::MAX as i32);
+        debug_assert!(new > Score::MIN as i32);
+        debug_assert!(new <= HH_MAX as i32);
+        debug_assert!(new >= -HH_MAX as i32);
+        
+        self.set_history(m, new as Score);
+    }
+
+    fn set_history(&mut self, m: PieceMove, s: Score) {
+        let a = m.to() as usize;
+        let b = m.from() as usize;
+        let c = self.side() as usize;
+        self.history[c][b][a] = s;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!         assert_eq!(game.move_to_san(m), "Bxc4");
 //!
 //!         game.make_move(m);
-//!         game.history.push(m); // Keep track of the moves played
+//!         game.plies.push(m); // Keep track of the moves played
 //!
 //!         println!("Engine played {}", m.to_lan());
 //!     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,9 @@ pub mod fen;
 /// Game engine
 pub mod game;
 
+/// History heuristic
+pub mod history;
+
 /// Portable Game Notation support
 pub mod pgn;
 

--- a/src/pgn.rs
+++ b/src/pgn.rs
@@ -154,7 +154,7 @@ impl ToPGN for Game {
         };
         pgn.set_result(result);
 
-        let moves = self.history.clone();
+        let moves = self.plies.clone();
         self.load_fen(&starting_fen).unwrap();
 
         let mut first_move = true;
@@ -171,7 +171,7 @@ impl ToPGN for Game {
             line.push_str(&self.move_to_san(m));
 
             self.make_move(m);
-            self.history.push(m);
+            self.plies.push(m);
 
             if self.is_mate() {
                 line.push('#');
@@ -226,7 +226,7 @@ impl LoadPGN for Game {
                 self.moves.clear_all();
                 if let Some(m) = self.parse_move(word) {
                     self.make_move(m);
-                    self.history.push(m);
+                    self.plies.push(m);
 
                     callback(self);
                 }
@@ -263,7 +263,7 @@ mod tests {
         ];
         for m in moves {
             game.make_move(m);
-            game.history.push(m);
+            game.plies.push(m);
         }
         let pgn = game.to_pgn();
 
@@ -286,15 +286,15 @@ mod tests {
         let s1 = fs::read_to_string("tests/fool.pgn").unwrap();
         let pgn = PGN::from(s1.as_str());
         game.load_pgn(pgn);
-        assert_eq!(game.history.len(), 4);
+        assert_eq!(game.plies.len(), 4);
 
         let s2 = fs::read_to_string("tests/zukertort_vs_steinitz_1886.pgn").unwrap();
         let pgn = PGN::from(s2.as_str());
         game.load_pgn(pgn);
-        assert_eq!(game.history.len(), 58);
+        assert_eq!(game.plies.len(), 58);
 
         let pgn = PGN::from(format!("{}\n{}", s1, s2).as_str());
         game.load_pgn(pgn);
-        assert_eq!(game.history.len(), 58);
+        assert_eq!(game.plies.len(), 58);
     }
 }

--- a/src/piece_move.rs
+++ b/src/piece_move.rs
@@ -8,10 +8,10 @@ use crate::common::*;
 use crate::piece::PieceChar;
 use crate::square::SquareExt;
 
-pub const BEST_MOVE_SCORE:    u8 = 255;
-pub const KILLER_MOVE_SCORE:  u8 = 254;
-pub const GOOD_CAPTURE_SCORE: u8 = 64;
-pub const QUIET_MOVE_SCORE:   u8 = 0;
+pub const BEST_MOVE_SCORE:    Score = 255;
+pub const KILLER_MOVE_SCORE:  Score = 254;
+pub const GOOD_CAPTURE_SCORE: Score = 64;
+pub const QUIET_MOVE_SCORE:   Score = 0;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct PieceMove(u16);

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -117,9 +117,12 @@ impl PieceMoveGenerator for Game {
                     self.moves[i].score += GOOD_CAPTURE_SCORE;
                 }
                 debug_assert!(self.moves[i].score < BEST_MOVE_SCORE);
+                debug_assert!(self.moves[i].score > 0);
             } else {
                 let m = self.moves[i].item;
-                self.moves[i].score = self.get_history(m) - 16384;
+                self.moves[i].score = self.get_history(m) - HH_MAX;
+                debug_assert!(self.moves[i].score < 0);
+                debug_assert!(self.moves[i].score > -HH_MAX);
             }
             for j in a..i {
                 if self.moves[j].score < self.moves[i].score {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -89,17 +89,17 @@ impl PieceMoveGenerator for Game {
                 self.moves.add_rooks_moves(&self.bitboards, side);
                 self.moves.add_queens_moves(&self.bitboards, side);
 
-                if self.moves.stage() == PieceMoveListStage::Capture {
-                    if !self.moves.skip_ordering {
-                        self.sort_moves();
-                    }
-                } else { // Castlings
+                if self.moves.stage() == PieceMoveListStage::QuietPieceMove {
                     if self.can_king_castle(side) {
                         self.moves.add_king_castle(side);
                     }
                     if self.can_queen_castle(side) {
                         self.moves.add_queen_castle(side);
                     }
+                }
+
+                if !self.moves.skip_ordering {
+                    self.sort_moves();
                 }
             },
             _ => () // Nothing to do in `BestPieceMove` or `Done` stages

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -8,6 +8,7 @@ use crate::attack::Attack;
 use crate::attack::piece_attacks;
 use crate::bitboard::BitboardExt;
 use crate::game::Game;
+use history::HistoryHeuristic;
 use crate::piece_move::*;
 use crate::piece_move_list::PieceMoveListStage;
 use crate::piece::PieceAttr;
@@ -122,7 +123,7 @@ impl PieceMoveGenerator for Game {
                 let history_score = self.get_history(self.moves[i].item);
                 self.moves[i].score = history_score - HH_MAX;
                 debug_assert!(self.moves[i].score <= QUIET_MOVE_SCORE);
-                debug_assert!(self.moves[i].score >= -HH_MAX);
+                debug_assert!(self.moves[i].score >= - 2 * HH_MAX);
             }
             for j in a..i {
                 if self.moves[j].score < self.moves[i].score {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -21,7 +21,7 @@ lazy_static! {
     // RxP =  4, RxN = 12, RxB = 20, RxR = 28, RxQ = 36, RxK = 44
     // QxP =  3, QxN = 11, QxB = 19, QxR = 27, QxQ = 35, QxK = 43
     // KxP =  2, KxN = 10, KxB = 18, KxR = 26, KxQ = 34, KxK = 42
-    pub static ref MVV_LVA_SCORES: [[u8; 13]; 13] = {
+    pub static ref MVV_LVA_SCORES: [[Score; 13]; 13] = {
         let pieces = [EMPTY, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING];
         let mut mvv_lva_scores = [[0; 13]; 13];
         for i in 1..7 {
@@ -58,7 +58,7 @@ pub trait PieceMoveGenerator {
 
 trait PieceMoveGeneratorExt {
     fn is_move_legal(&mut self, m: PieceMove) -> bool;
-    fn mvv_lva(&self, m: PieceMove) -> u8;
+    fn mvv_lva(&self, m: PieceMove) -> Score;
     fn can_king_castle(&mut self, side: Color) -> bool;
     fn can_queen_castle(&mut self, side: Color) -> bool;
     fn can_castle_on(&mut self, side: Color, wing: Piece) -> bool;
@@ -117,6 +117,10 @@ impl PieceMoveGenerator for Game {
                     self.moves[i].score += GOOD_CAPTURE_SCORE;
                 }
                 debug_assert!(self.moves[i].score < BEST_MOVE_SCORE);
+            } else {
+                let m = self.moves[i].item;
+                let score = self.get_history(m) / GOOD_CAPTURE_SCORE as Score;
+                self.moves[i].score = -(16384 - score);
             }
             for j in a..i {
                 if self.moves[j].score < self.moves[i].score {
@@ -435,7 +439,7 @@ impl PieceMoveGeneratorExt for Game {
         }
     }
 
-    fn mvv_lva(&self, m: PieceMove) -> u8 {
+    fn mvv_lva(&self, m: PieceMove) -> Score {
         let a = self.board[m.from() as usize].kind();
         let v = if m.is_en_passant() {
             PAWN

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -117,11 +117,11 @@ impl PieceMoveGenerator for Game {
                     self.moves[i].score += GOOD_CAPTURE_SCORE;
                 }
                 debug_assert!(self.moves[i].score < BEST_MOVE_SCORE);
-                debug_assert!(self.moves[i].score > 0);
-            } else {
-                let m = self.moves[i].item;
-                self.moves[i].score = self.get_history(m) - HH_MAX;
-                debug_assert!(self.moves[i].score < 0);
+                debug_assert!(self.moves[i].score > QUIET_MOVE_SCORE);
+            } else if self.moves[i].score == QUIET_MOVE_SCORE {
+                let history_score = self.get_history(self.moves[i].item);
+                self.moves[i].score = history_score - HH_MAX;
+                debug_assert!(self.moves[i].score < QUIET_MOVE_SCORE);
                 debug_assert!(self.moves[i].score >= -HH_MAX);
             }
             for j in a..i {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -122,7 +122,7 @@ impl PieceMoveGenerator for Game {
                 let m = self.moves[i].item;
                 self.moves[i].score = self.get_history(m) - HH_MAX;
                 debug_assert!(self.moves[i].score < 0);
-                debug_assert!(self.moves[i].score > -HH_MAX);
+                debug_assert!(self.moves[i].score >= -HH_MAX);
             }
             for j in a..i {
                 if self.moves[j].score < self.moves[i].score {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -119,8 +119,7 @@ impl PieceMoveGenerator for Game {
                 debug_assert!(self.moves[i].score < BEST_MOVE_SCORE);
             } else {
                 let m = self.moves[i].item;
-                let score = self.get_history(m) / GOOD_CAPTURE_SCORE as Score;
-                self.moves[i].score = -(16384 - score);
+                self.moves[i].score = self.get_history(m) - 16384;
             }
             for j in a..i {
                 if self.moves[j].score < self.moves[i].score {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -121,7 +121,7 @@ impl PieceMoveGenerator for Game {
             } else if self.moves[i].score == QUIET_MOVE_SCORE {
                 let history_score = self.get_history(self.moves[i].item);
                 self.moves[i].score = history_score - HH_MAX;
-                debug_assert!(self.moves[i].score < QUIET_MOVE_SCORE);
+                debug_assert!(self.moves[i].score <= QUIET_MOVE_SCORE);
                 debug_assert!(self.moves[i].score >= -HH_MAX);
             }
             for j in a..i {

--- a/src/piece_move_generator.rs
+++ b/src/piece_move_generator.rs
@@ -8,7 +8,7 @@ use crate::attack::Attack;
 use crate::attack::piece_attacks;
 use crate::bitboard::BitboardExt;
 use crate::game::Game;
-use history::HistoryHeuristic;
+use crate::history::HistoryHeuristic;
 use crate::piece_move::*;
 use crate::piece_move_list::PieceMoveListStage;
 use crate::piece::PieceAttr;

--- a/src/piece_move_list.rs
+++ b/src/piece_move_list.rs
@@ -24,6 +24,13 @@ impl<T, S> Scored<T, S> {
     }
 }
 
+impl<T, S> From<Scored<T, S>> for (T, S) {
+    fn from(s: Scored<T, S>) -> (T, S) {
+        let Scored { item, score } = s;
+        (item, score)
+    }
+}
+
 #[repr(u8)]
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Debug)]
 pub enum PieceMoveListStage { // If we don't care about `PartialOrd` we could do:

--- a/src/piece_move_list.rs
+++ b/src/piece_move_list.rs
@@ -53,7 +53,7 @@ pub struct PieceMoveList {
     // ply up to `MAX_PLY`, the theoretical maximum number of plies in a chess
     // game. And likewise it must be able to store the generated moves up to
     // the maximum of any chess position `MAX_MOVES`.
-    lists: [[Scored<PieceMove, u8>; MAX_MOVES]; MAX_PLY],
+    lists: [[Scored<PieceMove, Score>; MAX_MOVES]; MAX_PLY],
 
     // Number of moves at a given ply.
     sizes: [usize; MAX_PLY],
@@ -395,15 +395,15 @@ impl Iterator for PieceMoveList {
 }
 
 impl Index<usize> for PieceMoveList {
-    type Output = Scored<PieceMove, u8>;
+    type Output = Scored<PieceMove, Score>;
 
-    fn index(&self, index: usize) -> &Scored<PieceMove, u8> {
+    fn index(&self, index: usize) -> &Scored<PieceMove, Score> {
         &self.lists[self.ply][index]
     }
 }
 
 impl IndexMut<usize> for PieceMoveList {
-    fn index_mut(&mut self, index: usize) -> &mut Scored<PieceMove, u8> {
+    fn index_mut(&mut self, index: usize) -> &mut Scored<PieceMove, Score> {
         &mut self.lists[self.ply][index]
     }
 }

--- a/src/protocols/cli.rs
+++ b/src/protocols/cli.rs
@@ -445,8 +445,8 @@ impl CLI {
     }
 
     fn cmd_undo(&mut self) -> Result<State, Box<dyn Error>> {
-        if self.game.history.len() > 0 {
-            if let Some(m) = self.game.history.pop() {
+        if self.game.plies.len() > 0 {
+            if let Some(m) = self.game.plies.pop() {
                 self.game.undo_move(m);
             }
         }
@@ -481,7 +481,7 @@ impl CLI {
             }
 
             self.game.make_move(parsed_move);
-            self.game.history.push(parsed_move);
+            self.game.plies.push(parsed_move);
 
             if self.show_board {
                 println!();
@@ -791,7 +791,7 @@ impl CLI {
 
             if play {
                 self.game.make_move(m);
-                self.game.history.push(m);
+                self.game.plies.push(m);
 
                 if self.show_board {
                     println!();

--- a/src/protocols/uci.rs
+++ b/src/protocols/uci.rs
@@ -196,7 +196,7 @@ impl UCI {
         for s in moves {
             let m = self.game.move_from_lan(s);
             self.game.make_move(m);
-            self.game.history.push(m);
+            self.game.plies.push(m);
         }
     }
 

--- a/src/protocols/xboard.rs
+++ b/src/protocols/xboard.rs
@@ -82,17 +82,17 @@ impl XBoard {
     }
 
     fn cmd_undo(&mut self) {
-        if self.game.history.len() > 0 {
-            let m = self.game.history.pop().unwrap();
+        if self.game.plies.len() > 0 {
+            let m = self.game.plies.pop().unwrap();
             self.game.undo_move(m);
         }
     }
 
     fn cmd_remove(&mut self) {
-        let m = self.game.history.pop().unwrap();
+        let m = self.game.plies.pop().unwrap();
         self.game.undo_move(m);
 
-        let m = self.game.history.pop().unwrap();
+        let m = self.game.plies.pop().unwrap();
         self.game.undo_move(m);
     }
 
@@ -166,7 +166,7 @@ impl XBoard {
 
         let m = self.game.move_from_lan(args[0]);
         self.game.make_move(m);
-        self.game.history.push(m);
+        self.game.plies.push(m);
 
         if !self.force {
             self.think();
@@ -187,7 +187,7 @@ impl XBoard {
             },
             Some(m) => {
                 self.game.make_move(m);
-                self.game.history.push(m);
+                self.game.plies.push(m);
 
                 println!("move {}", m.to_lan());
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -426,15 +426,16 @@ impl Search for Game {
                     if !m.is_capture() {
                         self.moves.add_killer_move(m);
 
-                        let d = depth as Score;
+                        let d = depth as usize;
                         //let x = 300; // TODO: Tune this
                         //let y = 250; // TODO: Tune this
-                        let z = HH_MAX;
+                        let z = HH_MAX as usize;
                         //let bonus = (d * x - y).clamp(0, z);
                         let bonus = (d * d).min(z);
-                        let old = self.get_history(m);
-                        let new = old + bonus - bonus * (old / z); // Gravity
-                        self.set_history(m, new);
+                        let old = self.get_history(m) as usize;
+                        let new = old + bonus - old * bonus / z; // Gravity
+                        debug_assert!(new < Score::MAX as usize);
+                        self.set_history(m, new as Score);
                     }
                     self.tt.set(hash, depth, score, m, Bound::Lower);
                     return score;

--- a/src/search.rs
+++ b/src/search.rs
@@ -14,6 +14,7 @@ use crate::eval::Eval;
 #[cfg(feature = "std")]
 use crate::fen::FEN;
 use crate::game::Game;
+use crate::history::HistoryHeuristic;
 use crate::piece_move::PieceMove;
 use crate::piece_move_generator::PieceMoveGenerator;
 use crate::piece_move_notation::PieceMoveNotation;
@@ -423,19 +424,30 @@ impl Search for Game {
 
             if score > alpha {
                 if score >= beta {
-                    if !m.is_capture() {
-                        self.moves.add_killer_move(m);
+                    // Killer Heuristic (HH)
+                    let kh_allowed = !m.is_capture();
 
-                        let d = depth as usize;
-                        //let x = 300; // TODO: Tune this
-                        //let y = 250; // TODO: Tune this
-                        let z = HH_MAX as usize;
-                        //let bonus = (d * x - y).clamp(0, z);
-                        let bonus = (d * d).min(z);
-                        let old = self.get_history(m) as usize;
-                        let new = old + bonus - old * bonus / z; // Gravity
-                        debug_assert!(new < Score::MAX as usize);
-                        self.set_history(m, new as Score);
+                    if kh_allowed {
+                        self.moves.add_killer_move(m);
+                    }
+
+                    // History Heuristic (HH)
+                    let hh_allowed = !m.is_capture();
+
+                    if hh_allowed {
+                        // 1. Give a bonus to the current move
+                        self.inc_history(m, depth);
+
+                        // 2. Give a malus to the previous quiet moves that
+                        // failed to cause a cutoff
+                        let n = self.moves.index() - 1;
+                        for i in 1..n { // Skip first move
+                            let (previous_move, score) = self.moves[i].into();
+                            if score > 0 { // Skip noisy moves
+                                continue;
+                            }
+                            self.dec_history(previous_move, depth);
+                        }
                     }
                     self.tt.set(hash, depth, score, m, Bound::Lower);
                     return score;

--- a/src/search.rs
+++ b/src/search.rs
@@ -437,7 +437,7 @@ impl Search for Game {
                         self.moves.add_killer_move(m);
                     }
 
-                    // History Heuristic (HH)
+                    // History Heuristic (HH / 20 ELO)
                     let hh_allowed = !m.is_capture();
 
                     if hh_allowed {

--- a/src/search.rs
+++ b/src/search.rs
@@ -424,7 +424,7 @@ impl Search for Game {
 
             if score > alpha {
                 if score >= beta {
-                    // Killer Heuristic (HH)
+                    // Killer Heuristic (KH)
                     let kh_allowed = !m.is_capture();
 
                     if kh_allowed {

--- a/src/search.rs
+++ b/src/search.rs
@@ -426,12 +426,13 @@ impl Search for Game {
                         self.moves.add_killer_move(m);
 
                         let d = depth as Score;
-                        let x = 300;
-                        let y = 250;
+                        //let x = 300; // TODO: Tune this
+                        //let y = 250; // TODO: Tune this
                         let z = 16384;
-                        let bonus = (d * x - y).clamp(0, z);
+                        //let bonus = (d * x - y).clamp(0, z);
+                        let bonus = (d * d).min(z);
                         let old = self.get_history(m);
-                        let new = old + bonus - bonus.abs() * (old / z);
+                        let new = old + bonus - bonus * (old / z); // Gravity
                         self.set_history(m, new);
                     }
                     self.tt.set(hash, depth, score, m, Bound::Lower);

--- a/src/search.rs
+++ b/src/search.rs
@@ -75,6 +75,7 @@ impl Search for Game {
     fn search(&mut self, depths: Range<Depth>) -> Option<PieceMove> {
         self.nodes_count = 0;
         self.tt.reset();
+        self.clear_history();
 
         // NOTE: `clear_all()` will zero everything internally, including
         // ply counter, while `clear()` will just reset the counter for

--- a/src/search.rs
+++ b/src/search.rs
@@ -424,6 +424,15 @@ impl Search for Game {
                 if score >= beta {
                     if !m.is_capture() {
                         self.moves.add_killer_move(m);
+
+                        let d = depth as Score;
+                        let x = 300;
+                        let y = 250;
+                        let z = 16384;
+                        let bonus = (d * x - y).clamp(0, z);
+                        let old = self.get_history(m);
+                        let new = old + bonus - bonus.abs() * (old / z);
+                        self.set_history(m, new);
                     }
                     self.tt.set(hash, depth, score, m, Bound::Lower);
                     return score;

--- a/src/search.rs
+++ b/src/search.rs
@@ -428,7 +428,7 @@ impl Search for Game {
                         let d = depth as Score;
                         //let x = 300; // TODO: Tune this
                         //let y = 250; // TODO: Tune this
-                        let z = 16384;
+                        let z = HH_MAX;
                         //let bonus = (d * x - y).clamp(0, z);
                         let bonus = (d * d).min(z);
                         let old = self.get_history(m);

--- a/src/search.rs
+++ b/src/search.rs
@@ -817,7 +817,7 @@ mod tests {
         for s in moves {
             let m = game.move_from_lan(s);
             game.make_move(m);
-            game.history.push(m);
+            game.plies.push(m);
         }
 
         game.nodes_count = 0;

--- a/tests/wac.epd
+++ b/tests/wac.epd
@@ -196,7 +196,7 @@ r3k3/ppp2Npp/4Bn2/2b5/1n1pp3/N4P2/PPP3qP/R2QKR2 b Qq - bm Nd3+; id "WAC.192";
 rr4k1/p1pq2pp/Q1n1pn2/2bpp3/4P3/2PP1NN1/PP3PPP/R1B1K2R b KQ - bm Nb4; id "WAC.196";
 7k/1p4p1/7p/3P1n2/4Q3/2P2P2/PP3qRP/7K b - - bm Qf1+; id "WAC.197";
 2br2k1/ppp2p1p/4p1p1/4P2q/2P1Bn2/2Q5/PP3P1P/4R1RK b - - bm Rd3; id "WAC.198";
-r1br2k1/pp2nppp/2n5/1B1q4/Q7/4BN2/PP3PPP/2R2RK1 w - - bm Bxc6 Rfd1; id "WAC.199";
+r1br2k1/pp2nppp/2n5/1B1q4/Q7/4BN2/PP3PPP/2R2RK1 w - - bm Bxc6 Rcd1 Rfd1; id "WAC.199";
 2rqrn1k/pb4pp/1p2pp2/n2P4/2P3N1/P2B2Q1/1B3PPP/2R1R1K1 w - - bm Bxf6; id "WAC.200";
 2b2r1k/4q2p/3p2pQ/2pBp3/8/6P1/1PP2P1P/R5K1 w - - bm Ra7; id "WAC.201";
 QR2rq1k/2p3p1/3p1pPp/8/4P3/8/P1r3PP/1R4K1 b - - bm Rxa2; id "WAC.202";

--- a/tests/wac.rs
+++ b/tests/wac.rs
@@ -31,10 +31,11 @@ fn test_wac() {
         game.load_fen(fen).unwrap();
         game.clock = Clock::new(1, 1000); // search for 1 second
 
+        //game.is_search_verbose = true;
         let m = game.search(1..99).unwrap();
         let best_move = game.move_to_san(m);
 
-        println!("{} <- {}", moves, best_move);
+        println!("{} bm{} <- {}", fen, moves, best_move);
 
         assert!(moves.contains(&best_move));
     }


### PR DESCRIPTION
https://www.chessprogramming.org/History_Heuristic

This PR add history heuristic that give a bonus to a move that cause a beta cutoff in the search tree and malus to every quiet moves tried before it. This will allow the engine to improve move ordering by sorting quiet moves.