### PR TITLE
Fix internal iterative deepening

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -333,8 +333,8 @@ impl Search for Game {
         // get it by searching the position at a reduced depth.
         let iid_allowed = is_pv && best_move.is_null();
 
-        if iid_allowed && depth > 3 {
-            self.search_node(-beta, -alpha, depth / 2, ply + 1);
+        if iid_allowed && depth > 2 {
+            self.search_node(alpha, beta, depth - 2, ply);
 
             if let Some(t) = self.tt.get(hash) {
                 best_move = t.best_move();

--- a/src/search.rs
+++ b/src/search.rs
@@ -274,7 +274,7 @@ impl Search for Game {
         let mut best_score = alpha;
         let old_alpha = alpha; // To test if best score raise initial alpha
 
-        // Try to get the best move from transposition_table table
+        // Try to get the best move from transposition table (TT / 175 ELO)
         if let Some(t) = self.tt.get(hash) {
             if !is_pv && t.depth() >= depth {
                 match t.bound() {
@@ -302,7 +302,7 @@ impl Search for Game {
 
         let is_in_check = self.is_check(side);
 
-        // Null Move Pruning (NMP)
+        // Null Move Pruning (NMP / 95 ELO)
         let pieces_count = self.bitboard(side).count();
         let pawns_count = self.bitboard(side | PAWN).count();
         let is_pawn_ending = pieces_count == pawns_count + 1; // pawns + king
@@ -327,7 +327,7 @@ impl Search for Game {
             }
         }
 
-        // Internal Iterative Deepening (IID)
+        // Internal Iterative Deepening (IID / 0 ELO)
         //
         // If we didn't get a best move from the transposition_table table,
         // get it by searching the position at a reduced depth.
@@ -373,7 +373,7 @@ impl Search for Game {
                 let is_giving_check = self.is_check(side ^ 1);
                 let mut r = 0; // Depth reduction
 
-                // Futility Pruning (FP)
+                // Futility Pruning (FP / 60 ELO)
                 let fp_allowed =
                     !is_pv &&
                     !is_in_check &&
@@ -389,7 +389,7 @@ impl Search for Game {
                     }
                 }
 
-                // Late Move Reduction (LMR)
+                // Late Move Reduction (LMR / 35 ELO)
                 let lmr_allowed =
                     !is_pv &&
                     !is_in_check &&
@@ -402,6 +402,7 @@ impl Search for Game {
                     if depth > 4 {
                         r += depth / 4;
                     }
+                    // TODO: Reduce more based on moves count
                 }
 
                 // Search the other moves with the reduced window
@@ -423,6 +424,7 @@ impl Search for Game {
             if score > alpha {
                 if score >= beta {
                     if !m.is_capture() {
+                        // Killer Heuristic (KH / 50 ELO)
                         self.moves.add_killer_move(m);
                     }
                     self.tt.set(hash, depth, score, m, Bound::Lower);


### PR DESCRIPTION
The search function inside IID was incorrectly called with the same arguments as after making a move, but fixing this didn't lead to any ELO gain. In fact removing IID completely doesn't change anything at short time control at least:

```
Rank Name                                       Elo    +    - games score oppo. draws
   1 Akimbo 0.3.0                              2544    4    4 40536   87%  2205    9%
   2 Sungorus 1.4                              2339    3    3 40570   67%  2205   13%
   3 FoxSEE 8.2                                2310    3    3 40556   63%  2205   14%
   4 Robocide 0.1                              2271    3    3 40542   58%  2205   14%
   5 Little Wing v0.7.0-27-g60faf4c-no-iid XB  2213    4    4 31263   49%  2223   13%
   6 Little Wing v0.7.0-27-g60faf4c XB         2213    4    4 34549   49%  2223   13%
   7 Little Wing v0.7.0-27-g60faf4c-iid2 XB    2212    3    3 37202   49%  2223   13%
   8 Little Wing v0.7.0-27-g60faf4c-iid4 XB    2212    4    4 27557   49%  2223   13%
   9 Little Wing v0.7.0-27-g60faf4c-iid3 XB    2211    4    4 33850   49%  2223   13%
  10 Little Wing v0.7.0-27-g60faf4c-iid5 XB    2207    5    5 17031   48%  2223   13%
  11 MORA 1.1.0                                2200    2    2 80360   50%  2203   17%
  12 Odonata 0.4.0                             2189    3    3 40542   48%  2205   16%
  13 Spacedog 0.97.7                           2182    2    2 80386   47%  2203   17%
  14 Little Wing v0.7.0-27-g60faf4c-iid1 XB    2180    4    4 23533   45%  2223   12%
  15 Little Wing v0.7.0-27-g60faf4c-no-lmr XB  2180    8    8  7371   45%  2223   13%
  16 Little Wing v0.7.0-27-g60faf4c-no-kh XB   2152    6    6 11021   42%  2223   13%
  17 Little Wing v0.7.0-27-g60faf4c-no-fp XB   2151    9    9  5023   42%  2223   13%
  18 Little Wing v0.7.0-24-g98a1a13 XB         2137    3    3 46403   53%  2106   16%
  19 Little Wing v0.7.0-27-g60faf4c-no-nmp XB  2119    7    7  9040   38%  2223   12%
  20 Little Wing v0.7.0-27-g60faf4c-no-tt XB   2039   11   11  4099   30%  2223   10%
  21 Cadabra 2.0.1                             2039    3    3 40551   30%  2205   12%
  22 Achillees 1.0                             1935    3    3 80347   20%  2203    9%
```

I tried various things to make it work but at best I got the same result as not using IID at all.

```
  +------+--------+----+-----+-----+
  | ELO  | Patch  | PV |  D  |  R  |
  +------+--------+----+-----+-----+
  | 2214 | trunk  |    |     |     |
  | 2214 | no-iid |    |     |     |
  | 2213 | iid4   | F  | > 4 | - 2 |
  | 2213 | iid2   | T  | > 2 | - 2 |
  | 2212 | iid3   | F  | > 2 | - 2 |
  | 2208 | iid5   | T  | > 4 | - 2 |
  | 2181 | iid1   | T  | > 3 | - 3 |
  +------+--------+----+-----+-----+
```

For now I'll keep a harmless version that is searching at depth - 2 only for the PV node at depth > 2 to see if I can measure some gains at longer time control and after improving other parts of the engine.