### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 0.8.0 (2026-03-03)
 ### Fixed
 - Fix insertion sort in movegen (#143)
 - Do check before search in root (#131)
@@ -42,7 +44,7 @@
 - Update rustyline-derive requirement from 0.7.0 to 0.8.0 (#106)
 - Update crates (#96)
 
-### 0.7.0 (2021-08-21)
+## 0.7.0 (2021-08-21)
 ### Fixed
 - Fix getopts parsing (#75)
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 A chess engine rated at 2050+ ELO, compatible with both UCI and XBoard
 protocols, with a nice CLI, and a documented library.
 """
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT"
 authors = ["Vincent Ollivier <v@vinc.cc>"]
 repository = "https://github.com/vinc/littlewing"


### PR DESCRIPTION
## 0.8.0 (2026-03-03)
### Fixed
- Fix insertion sort in movegen (#143)
- Do check before search in root (#131)
- Fix internal iterative deepening (#130)
- Fix UCI issue with PV after draw (#112)
- Fix invalid claim (#103)
- Fix std (#100)
- Fix clippy warnings (#99)
### Added
- Add TT prefetch (#145)
- Add check extension (#142)
- Add history heuristic (#128)
- Add improving heuristic (#139)
- Add libm to compute log in no_std (#146)
- Add noisy/quiet moves (#144)
- Add reverse futility pruning (#135)
- Add tempo to eval (#127)
- Add automated tuning (#122)
- Add depth command (#101)
### Changed
- Reduce futility pruning margin (#138)
- Refactor transposition table (#137)
- Update LMR (#140)
- Update eval params (#133)
- Replace Bencher by Criterion (#123)
- Improve UCI support (#114)
- Use safe lockless transposition table (#113)
- Set default number of moves for UCI go command (#104)
- Migrate from 2015 edition to 2018 (#98)
- Change license from GPL to MIT (#97)
### Bumped
- Update criterion requirement from 0.7 to 0.8 (#126)
- Update rand crates (#120)
- Update rustyline requirement from 11.0.0 to 17.0.2 (#119)
- Update dirs requirement from 5.0.1 to 6.0.0 (#118)
- Upgrade GitHub Actions cache (#111)
- Update dirs requirement from 4.0.0 to 5.0.1 (#110)
- Update rustyline requirement from 10.0.0 to 11.0.0 (#105)
- Update rustyline-derive requirement from 0.7.0 to 0.8.0 (#106)
- Update crates (#96)